### PR TITLE
Separate configurable variable into a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ Once you've installed the required libraries, you should be able to simply run:
 ./audit.py hosts (jira, confluence, stash, or all)
 ```
 
+example:
+```
+./audit.py jira
+```
+```
+./audit.py jira confluence
+```
+```
+./audit.py jira all
+```
+
 As it runs, the script will echo out each Plugin it finds, along with
 description, current version, and pricing; it then updates the sheet with this
 information.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ example:
 ./audit.py jira confluence
 ```
 ```
-./audit.py jira all
+./audit.py all
 ```
 
 As it runs, the script will echo out each Plugin it finds, along with

--- a/README.md
+++ b/README.md
@@ -5,17 +5,16 @@ Confluence, and Bitbucket with a Google Sheet for documentation and auditing.
 
 ## Getting Started
 
-You will need to update **audit.py** for your environment:
-* **sheet_url** - URL of your Google Sheet. A sample that you can copy is here:
+You will need to update **config_audit.py** for your environment:
+* **google_sheet_url** - URL of your Google Sheet. A sample that you can copy is here:
 https://docs.google.com/spreadsheets/d/1iBHfz0TOyPxC3JRQp30v2Qs9lHbKfwOG-eZ53BK_ok0/edit#gid=0
   * Replace `YOURGOOGLESHEET` with your Google Sheet URL.
-* **possibletargets** - Sheet Names and URLs of your Confluence, JIRA, and Stash servers.
+* **target_url** - Sheet Names and URLs of your Confluence, JIRA, and Stash servers.
   * Replace `YOURCONFLUENCESERVER` with URL to your Confluence server.
   * Replace `YOURJIRASERVER` with URL to your Jira server.
   * Replace `YOURBITBUCKETSERVER` with URL to your Stash/Bitbucket server.
-
-You will also need to update **jira_credentials.py** with your username and
-password. (We assume the same credentials will work across all your servers.)
+*  **jira_credentials** - your username and password. (We assume the same credentials will 
+work across all your servers.)
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ Confluence, and Bitbucket with a Google Sheet for documentation and auditing.
 ## Getting Started
 
 You will need to update **audit.py** for your environment:
-* *sheet_url* - URL of your Google Sheet. A sample that you can copy is here:
+* **sheet_url** - URL of your Google Sheet. A sample that you can copy is here:
 https://docs.google.com/spreadsheets/d/1iBHfz0TOyPxC3JRQp30v2Qs9lHbKfwOG-eZ53BK_ok0/edit#gid=0
-* *possibletargets* - Sheet Names and URLs of your Confluence, JIRA, and Stash servers.
+  * Replace `YOURGOOGLESHEET` with your Google Sheet URL.
+* **possibletargets** - Sheet Names and URLs of your Confluence, JIRA, and Stash servers.
+  * Replace `YOURCONFLUENCESERVER` with URL to your Confluence server.
+  * Replace `YOURJIRASERVER` with URL to your Jira server.
+  * Replace `YOURBITBUCKETSERVER` with URL to your Stash/Bitbucket server.
 
 You will also need to update **jira_credentials.py** with your username and
 password. (We assume the same credentials will work across all your servers.)
@@ -42,8 +46,10 @@ information.
 **sheetscript.gs** is an Apps Script that can be added to your Google Sheet to
 automatically generate an email when licenses are about to expire. Additionally,
 it adds a pop-up alert to the sheet warning users not to edit any columns that
-may be overwritten by the audit.py script. You'll need to specify
-**emailAddress** and optionally, **daysprior** (default 7-day notice).
+may be overwritten by the audit.py script. You'll need to update **sheetscript.gs**
+then specify these values:
+* **emailAddress**, replace `YOUREMAILADDRESS` with your email address.
+* (optional) **daysprior** (default 7-day notice), replace `7` with your preferred day number.
 
 The [sample Google Sheet](https://docs.google.com/spreadsheets/d/1iBHfz0TOyPxC3JRQp30v2Qs9lHbKfwOG-eZ53BK_ok0/edit#gid=0)
 contains conditional formatting that automatically color codes cells

--- a/audit.py
+++ b/audit.py
@@ -22,6 +22,8 @@ import pygsheets
 from pprint import pprint
 import httplib2
 http_client = httplib2.Http(timeout=100)
+# import configuration file
+import config_audit as config
 
 from datetime import datetime, timezone
 from time import strftime, localtime
@@ -35,24 +37,23 @@ parser.add_argument('hosts', metavar='hosts', type=str, nargs='+',
 args = parser.parse_args()
 
 # Shared details
-import jira_credentials
-user = jira_credentials.user
-password = jira_credentials.password
+user = config.jira_credentials['user']
+password = config.jira_credentials['password']
 headers = {'X-Atlassian-Token': 'nocheck'}
 marketurl = 'https://marketplace.atlassian.com/'
 
 # Google Sheets details
 client = pygsheets.authorize(http_client=http_client)
 
-sheet_url = 'YOURGOOGLESHEET' 
+sheet_url = config.google_sheet_url
 
 ss = client.open_by_url(sheet_url)
 
 targets = {}
 
-possibletargets = {'Confluence': 'https://YOURCONFLUENCESERVER/',
-	'JIRA': 'https://YOURJIRASERVER/',
-	'Stash': 'https://YOURBITBUCKETSERVER/'}
+possibletargets = {'Confluence': config.target_url['confluence'],
+	'JIRA': config.target_url['jira'],
+	'Stash': config.target_url['stash']}
 
 for i in args.hosts:
 	if i == 'jira':

--- a/config_audit.py
+++ b/config_audit.py
@@ -14,5 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-user = 'YOURJIRAUSER'
-password = 'YOURJIRAPASSWORD'
+jira_credentials = {
+  'user': 'YOURJIRAUSER',
+  'password': 'YOURJIRAPASSWORD'}
+
+target_url = {
+  'confluence': 'https://YOURCONFLUENCESERVER/',
+  'jira': 'https://YOURJIRASERVER/',
+  'stash': 'https://YOURBITBUCKETSERVER/'}
+
+google_sheet_url = 'YOURGOOGLESHEET'

--- a/jira_credentials.py
+++ b/jira_credentials.py
@@ -14,5 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-user = YOURJIRAUSER
-password = YOURJIRAPASSWORD
+user = 'YOURJIRAUSER'
+password = 'YOURJIRAPASSWORD'


### PR DESCRIPTION
# Description
Separating configurable variable into a config file: `audit_config.py`
```
jira_credentials = {
  'user': 'YOURJIRAUSER',
  'password': 'YOURJIRAPASSWORD'}

target_url = {
  'confluence': 'https://YOURCONFLUENCESERVER/',
  'jira': 'https://YOURJIRASERVER/',
  'stash': 'https://YOURBITBUCKETSERVER/'}

google_sheet_url = 'YOURGOOGLESHEET'
```
This hopefully will make it easier for user to change config and know which variable they can config, instead of editing the `audit.py` themselves.

Readme also updated to reflect changes.

This already include [PR 1](https://github.com/google/atlassian-addons-audit-sheet/pull/1)
Note: I wanted to use YAML as config file, but then it will add more dependency, so I just used simple `.py` config file